### PR TITLE
Zmq cleanup fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 python = ">=3.10,<4.0"
 pyzmq = "^25.1.2"
 msgpack-python = "^0.5.6"
-volttron-core = ">=2.0.0rc26"
+volttron-core = ">=2.0.0rc34"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.2.2"

--- a/src/volttron/auth/zap/zap_authenticator.py
+++ b/src/volttron/auth/zap/zap_authenticator.py
@@ -66,6 +66,20 @@ class ZapAuthenticator(Authenticator):
     def is_authenticated(self, *, identity: Identity) -> bool:
         return identity in self._authenticated
 
+    def stop(self) -> None:
+        """Kill the ZAP greenlet and close the inproc socket.
+
+        Must be called when the owning context is torn down (e.g. when a
+        PlatformWrapper shuts down) so that the next context can successfully
+        bind inproc://zeromq.zap.01 again.
+        """
+        if self._zap_greenlet is not None and not self._zap_greenlet.dead:
+            self._zap_greenlet.kill(block=True, timeout=2)
+        try:
+            self.zap_socket.close(linger=0)
+        except Exception:
+            pass
+
     # def authenticate(self, *, credentials: Credentials) -> bool:
     #     if self._options.auth_enabled:
     #         if not self._credentials_store.has_identity(credentials.identity):

--- a/src/volttron/messagebus/zmq/zmq_connection.py
+++ b/src/volttron/messagebus/zmq/zmq_connection.py
@@ -84,8 +84,17 @@ class ZmqConnection(Connection):
     # def connect(self):
     #     self.open_connection(type=zmq.DEALER)
 
-    def disconnect(self):
-        self.close_connection()
+    def disconnect(self, linger=0):
+        """Stop the monitor, close the socket, and clear the socket reference."""
+        try:
+            if self._socket is not None:
+                self._socket.monitor(None, 0)
+        except Exception:
+            pass
+        try:
+            self.close_connection(linger)
+        except Exception:
+            pass
         self._socket = None
 
     def is_connected(self) -> bool:
@@ -191,9 +200,6 @@ class ZmqConnection(Connection):
             obj.args = deserialize_frames(obj.args)
 
         return obj
-
-    def disconnect(self):
-        self._socket.disconnect(self._url)
 
     def close_connection(self, linger=5):
         """This method closes ZeroMQ socket"""

--- a/src/volttron/messagebus/zmq/zmq_core.py
+++ b/src/volttron/messagebus/zmq/zmq_core.py
@@ -29,19 +29,16 @@ from volttron.utils import jsonrpc
 
 _log = logging.getLogger(__name__)
 
-__connection_builders__: dict[str, ZmqConnectionBuilder] = {}
-__agent_contexts__: dict[str, AgentContext] = {}
-
-
 @connection_builder
 class ZmqConnectionBuilder(ConnectionBuilder):
 
-    def __init__(self, address: str):
+    def __init__(self, address: str, agent_contexts: dict):
         self._address = address
+        self._agent_contexts = agent_contexts
 
     def build(self, credentials: Credentials) -> Connection:
 
-        context: AgentContext = __agent_contexts__.get(credentials.identity)
+        context: AgentContext = self._agent_contexts.get(credentials.identity)
 
         # Not an internal address
         if not self._address.startswith("inproc") and hasattr(credentials, "publickey"):
@@ -66,8 +63,12 @@ class ZmqConnectionBuilder(ConnectionBuilder):
 @core_builder
 class ZmqCoreBuilder(CoreBuilder):
 
+    def __init__(self):
+        self._agent_contexts: dict[str, AgentContext] = {}
+        self._connection_builders: dict[str, ZmqConnectionBuilder] = {}
+
     def build(self, *, context: AgentContext, owner: AbstractAgent = None) -> CoreLoop:
-        __agent_contexts__[context.credentials.identity] = context
+        self._agent_contexts[context.credentials.identity] = context
         opts = context.options
 
         try:
@@ -86,7 +87,9 @@ class ZmqCoreBuilder(CoreBuilder):
                        address=context.address,
                        reconnect_interval=opts.reconnect_interval,
                        agent_uuid=opts.agent_uuid,
-                       server_credentials=server_creds)
+                       server_credentials=server_creds,
+                       agent_contexts=self._agent_contexts,
+                       connection_builders=self._connection_builders)
 
 
 class ZmqCore(Core):
@@ -101,17 +104,23 @@ class ZmqCore(Core):
                  identity: str = None,
                  reconnect_interval: int = None,
                  server_credentials: Credentials = None,
-                 agent_uuid: str = None):
+                 agent_uuid: str = None,
+                 agent_contexts: dict = None,
+                 connection_builders: dict = None):
         if credentials is None and identity is None:
             identity = str(uuid.uuid4())
         elif credentials:
             identity = credentials.identity
         # address = "inproc://vip"
         # _log.error(f"ADDRESS hard coded to {address}")
-        builder = __connection_builders__.get(address)
+        if connection_builders is None:
+            connection_builders = {}
+        if agent_contexts is None:
+            agent_contexts = {}
+        builder = connection_builders.get(address)
         if not builder:
-            builder = ZmqConnectionBuilder(address=address)
-            __connection_builders__[address] = builder
+            builder = ZmqConnectionBuilder(address=address, agent_contexts=agent_contexts)
+            connection_builders[address] = builder
         super().__init__(owner=owner, credentials=credentials, connection_factory=builder)
 
         if credentials is None and server_credentials is not None or \
@@ -416,13 +425,8 @@ class ZmqCore(Core):
         # pre-finish
         try:
             self.connection.disconnect()
-            self._socket.monitor(None, 0)
-            self.connection.close_connection(1)
-        except AttributeError:
-            pass
-        except ZMQError as exc:
-            if exc.errno != ENOENT:
-                _log.exception("disconnect error")
+        except Exception:
+            _log.exception("Error during disconnect for %s", self.identity)
         finally:
             self._socket = None
         yield


### PR DESCRIPTION
- Improvements to resource management and context handling in the ZeroMQ
- Ensuring proper teardown of sockets and agent contexts to prevent resource leaks and binding issues, particularly during shutdown and context switching.

**This PR needs to be merged and pushed after [volttron core-pr 331](https://github.com/eclipse-volttron/volttron-core/pull/331) is pushed and deployed to PyPI**

Dependency update:

* Updated `volttron-core` dependency version from `>=2.0.0rc26` to `>=2.0.0rc34` in `pyproject.toml` for improved compatibility and access to recent features.

Resource management and teardown improvements:

* Added a `stop` method to `ZAPAuthenticator` in `zap_authenticator.py` to explicitly kill the ZAP greenlet and close the inproc socket, preventing issues when re-binding to `inproc://zeromq.zap.01`.
* Enhanced the `disconnect` method in `ZmqConnection` (`zmq_connection.py`) to stop the monitor, close the socket with a configurable linger, and clear the socket reference, ensuring proper cleanup.
* Improved error handling during disconnect and teardown in `ZmqCore.vip_loop()` to log exceptions and ensure sockets are properly set to `None`.

Agent context and connection builder management:

* Refactored `ZmqCoreBuilder` and `ZmqCore` in `zmq_core.py` to store and pass agent contexts and connection builders as instance attributes rather than using module-level globals, improving encapsulation and correctness in multi-agent scenarios. [[1]](diffhunk://#diff-2f20222252214ea55d4849e3202d6556888102337e06e332d2df11fa65f5eacbL32-R41) [[2]](diffhunk://#diff-2f20222252214ea55d4849e3202d6556888102337e06e332d2df11fa65f5eacbR66-R71) [[3]](diffhunk://#diff-2f20222252214ea55d4849e3202d6556888102337e06e332d2df11fa65f5eacbL89-R92) [[4]](diffhunk://#diff-2f20222252214ea55d4849e3202d6556888102337e06e332d2df11fa65f5eacbL104-R123)